### PR TITLE
Add support for switch "code-above"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.aux
+*.code
+*.log
+*.out
+
+*-cnltx-?.pdf
+*-cnltx-?.tex
+
+examples/cnltx-example.sty

--- a/cnltx-example.sty
+++ b/cnltx-example.sty
@@ -503,6 +503,8 @@
 \newbool{cnltx@local@frame@overwrite}
 
 \newbool {cnltx@sidebyside}
+\newbool {cnltx@codeabove}
+\booltrue{cnltx@codeabove}
 \newbool {cnltx@codeleft}
 \booltrue{cnltx@codeleft}
 \newbool {cnltx@codeonly}
@@ -547,6 +549,7 @@
   cnltx/.cd,
     side-by-side/.is if        = cnltx@sidebyside ,
     code-only/.is if           = cnltx@codeonly ,
+    code-above/.is if          = cnltx@codeabove ,
     code-left/.is if           = cnltx@codeleft ,
     compile/.is if             = cnltx@compile ,
     code-sep/.code             = \def\cnltx@examplesep{#1} ,
@@ -700,7 +703,7 @@
 }
 
 \newrobustcmd*\cnltx@source@input@start[1]{%
-  \ifboolexpr{ bool {cnltx@sidebyside} and not bool {cnltx@codeonly} }
+  \ifboolexpr{ bool {cnltx@sidebyside} and not bool {cnltx@codeonly} or not bool {cnltx@codeabove} }
     {%
       \adjustbox{
         % discard,
@@ -716,7 +719,7 @@
 
 \newrobustcmd*\cnltx@source@input@end{%
   \lst@EndWriteFile
-  \ifboolexpr{ bool {cnltx@sidebyside} and not bool {cnltx@codeonly} }
+  \ifboolexpr{ bool {cnltx@sidebyside} and not bool {cnltx@codeonly} or not bool {cnltx@codeabove} }
     {\egroup}{\cnltx@after@source@hook}%
 }
 
@@ -870,11 +873,23 @@
               \endminipage
             }%
         }
-        {% example below
-          \par\noindent\cnltx@examplesep
-          \cnltx@pre@example@hook
-          \cnltx@example@input{#1.code}%
-          \cnltx@after@example@hook
+        {% example and code stacked
+          \ifbool{cnltx@codeabove}
+            {% code above example
+              \par\noindent\cnltx@examplesep
+              \cnltx@pre@example@hook
+              \cnltx@example@input{#1.code}%
+              \cnltx@after@example@hook
+            }
+            {% example above code
+              \cnltx@pre@example@hook
+              \cnltx@example@input{#1.code}%
+              \cnltx@after@example@hook%
+              \vspace{-\baselineskip}\noindent\cnltx@examplesep\par
+              \cnltx@pre@source@hook
+              \unhbox\cnltx@example@box
+              \cnltx@after@source@hook
+            }%
         }%
     }%
   \ifbool{cnltx@compile}
@@ -905,7 +920,11 @@
               \endmdframed
               \cnltx@float@start
             }
-            {\par\noindent\cnltx@examplesep\par}%
+            {%
+              \ifbool{cnltx@codeabove}%
+                {\par\noindent\cnltx@examplesep\par}
+                {}
+            }%
           \cnltx@pre@example@hook
           \ifbool{cnltx@pagelist}
             {%
@@ -934,6 +953,15 @@
                   \stepcounter{cnltx@tmpa}%
                   \setcounter{cnltx@tmpb}{\numexpr\value{cnltx@tmpb}-1\relax}%
                 }
+            }%
+          \ifbool{cnltx@codeabove}%
+            {}
+            {%
+              \flushleft
+              \vspace{-\baselineskip}\par\noindent\cnltx@examplesep\par
+              \cnltx@pre@source@hook
+              \hspace{1em}\unhbox\cnltx@example@box
+              \cnltx@after@source@hook
             }%
           \ifbool{cnltx@float}
             {%
@@ -1119,6 +1147,7 @@ HISTORY:
 2019/11/01 v0.15  - fix `undefined control sequence \lst@gtexcs3' error
                   - fix `undefined control sequence \lst@gkeyword3' error
                   - fix `undefined control sequence \lst@gkeyword3' error
-TODO:
+2020/??           - new option `code-above`
 
+TODO:
 

--- a/cnltx_en.tex
+++ b/cnltx_en.tex
@@ -881,6 +881,10 @@ Both environments can be influenced by options:
     code box above is an example for the usage of this option.  This option
     has no effect on the \env{sourcecode} environment: is is already set for
     this environment.
+  \keybool{code-above}\Default{true}
+    If \code{true} the source is printed first and then the example. Otherwise,
+    the example is first printed and then the code. This option has no effect
+    on the \env{sourcecode} environment.
   \keybool{side-by-side}\Default{false}
     Typeset source and output side by side.  The code is input on the left and
     the output on the right.  Side by side examples are typeset in

--- a/examples/code-above-compile.tex
+++ b/examples/code-above-compile.tex
@@ -1,0 +1,20 @@
+\documentclass{article}
+\usepackage{cnltx-example}
+
+\begin{document}
+
+\begin{example}[code-above=true,compile]
+  \documentclass{standalone}
+  \begin{document}
+    First, the \LaTeX{} code is shown.
+  \end{document}
+\end{example}
+
+\begin{example}[code-above=false,compile]
+  \documentclass{standalone}
+  \begin{document}
+    First, this text is \emph{rendered}.
+  \end{document}
+\end{example}
+
+\end{document}

--- a/examples/code-above.tex
+++ b/examples/code-above.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\usepackage{cnltx-example}
+\begin{document}
+
+\begin{example}[code-above=true]
+  First, the \LaTeX{} code is shown.
+\end{example}
+
+\begin{example}[code-above=false]
+  First, this text is \emph{rendered}.
+\end{example}
+
+\end{document}


### PR DESCRIPTION
This fixes https://github.com/cgnieder/cnltx/issues/6 by adding a switch `code-above`.

Two example documents are added showing the different outputs:

Normal embedding:

![grafik](https://user-images.githubusercontent.com/1366654/83250800-fbd77300-a1a8-11ea-9180-942997557e28.png)

Compiled embedding:

![grafik](https://user-images.githubusercontent.com/1366654/83250847-06920800-a1a9-11ea-8df4-608d9948f648.png)

Hope, you'll like it!